### PR TITLE
Add dev host

### DIFF
--- a/acceptance-tests/features/support/env.rb
+++ b/acceptance-tests/features/support/env.rb
@@ -11,6 +11,6 @@
 #   Env.domain
 class Env
   def self.domain
-    (ENV['DOMAIN'] || 'http://localhost:5000')
+    (ENV['DOMAIN'] || 'http://deedapi.dev.service.gov.uk')
   end
 end

--- a/app/config.py
+++ b/app/config.py
@@ -2,4 +2,5 @@ import os
 
 DEBUG = True
 
-SQLALCHEMY_DATABASE_URI = os.getenv('DEED_DATABASE_URI', '')
+SQLALCHEMY_DATABASE_URI = os.getenv('DEED_DATABASE_URI',
+                                    'postgres:///deed_api')

--- a/puppet/deed_api/Puppetfile
+++ b/puppet/deed_api/Puppetfile
@@ -1,7 +1,7 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 mod 'LandRegistry/standard_env',
-  :git => 'git://github.com/LandRegistry/standard-env',
-  :ref => 'master'
+    git: 'git://github.com/LandRegistry/standard-env',
+    ref: 'master'
 
-mod "puppetlabs/postgresql"
+mod 'puppetlabs/postgresql'

--- a/puppet/deed_api/manifests/init.pp
+++ b/puppet/deed_api/manifests/init.pp
@@ -4,7 +4,8 @@ class deed_api (
     $host = '0.0.0.0',
     $source = 'git://github.com/LandRegistry/charges-deed-api',
     $branch_or_revision = 'master',
-    $domain = 'deedapi.*',
+    $subdomain = 'deedapi',
+    $domain = undef,
     $owner = 'vagrant',
     $group = 'vagrant'
 ) {
@@ -69,5 +70,9 @@ class deed_api (
   standard_env::db::postgres { $module_name:
     user     => $owner,
     password => $owner,
+  }
+
+  if $environment == 'development' {
+    standard_env::dev_host { $subdomain: }
   }
 }

--- a/puppet/deed_api/templates/nginx.conf.erb
+++ b/puppet/deed_api/templates/nginx.conf.erb
@@ -1,6 +1,10 @@
 server {
   listen 80;
-  server_name <%= @domain %>;
+  <% if @domain %>
+    server_name <%= @domain %>;
+  <% else %>
+    server_name <%= @subdomain %>.*;
+  <% end %>
 
   location / {
     proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
This pull request adds a host entry for the deed api to development deploys of the app and changes the acceptance tests to point to that new host.

The intention is to make the process of developing easier by not having to hoke around for port numbers and IPs.
