### PR TITLE
jenkins sh update for jobname db usage

### DIFF
--- a/bin/jenkins.sh
+++ b/bin/jenkins.sh
@@ -19,7 +19,11 @@ git submodule update --init
 
 rubocop=$?
 
-DEED_DATABASE_URI=postgres:///deed_api coverage run --source=app tests.py --xml
+createdb -O tomcat $JOB_NAME
+
+DEED_DATABASE_URI=postgres:///$JOB_NAME coverage run --source=app tests.py --xml
+
+dropdb $JOB_NAME
 
 test_pass=$?
 


### PR DESCRIPTION
Update charges-deed-api jenkins script to use dynamic databases built on JobName to stop multiple builds accessing the same DB
